### PR TITLE
Feat: implements the adapter interface using LSQUIC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module poghttp3
 
 go 1.23.0
+
+require github.com/mattn/go-pointer v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
+github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=

--- a/pkg/quic/adapter.go
+++ b/pkg/quic/adapter.go
@@ -14,6 +14,7 @@ type QuicAPI interface {
 	OnCanceledConn(cid QuicCID)
 	OnNewStream(stream QuicStream)
 	OnReadStream(stream QuicStream, data []byte)
+	OnWriteStream(stream QuicStream)
 }
 
 type QuicStream interface {

--- a/pkg/quic/adapter.go
+++ b/pkg/quic/adapter.go
@@ -19,6 +19,7 @@ type QuicAPI interface {
 
 type QuicStream interface {
 	io.WriteCloser
+	ID() uint64
 }
 
 type QuicCID interface {

--- a/pkg/quic/adapter.go
+++ b/pkg/quic/adapter.go
@@ -1,10 +1,25 @@
 package adapter
 
-type QuicAdapter interface {
-	onNewConnection(id []byte)
-	onNewStream(id int64)
-	onCanceledConn(id []byte)
-	onReadStream(id int64, data []byte)
-	writeStream(id int64, data []byte)
-	Listen()
+import (
+	"fmt"
+	"io"
+)
+
+type QuicServer interface {
+	Listen() error
+}
+
+type QuicAPI interface {
+	OnNewConnection(cid QuicCID)
+	OnCanceledConn(cid QuicCID)
+	OnNewStream(stream QuicStream)
+	OnReadStream(stream QuicStream, data []byte)
+}
+
+type QuicStream interface {
+	io.WriteCloser
+}
+
+type QuicCID interface {
+	fmt.Stringer
 }

--- a/pkg/quic/lsquic/CMakeLists.txt
+++ b/pkg/quic/lsquic/CMakeLists.txt
@@ -23,12 +23,13 @@ IF(BUILD_LSQUIC)
     INCLUDE_DIRECTORIES(lsquic/src/liblsquic)
     INCLUDE_DIRECTORIES(include)
     ADD_LIBRARY(lsquic_adapter SHARED ./src/logger.c ./src/cert.c ./src/server.c ./src/keylog.c ./src/ancillary.c)
-    TARGET_LINK_LIBRARIES(lsquic_adapter PRIVATE
+    SET(LIBS
+        lsquic_adapter
         ${CMAKE_SOURCE_DIR}/lsquic/src/liblsquic/liblsquic.so
         ${CMAKE_SOURCE_DIR}/boringssl/crypto/libcrypto.so
         ${CMAKE_SOURCE_DIR}/boringssl/ssl/libssl.so z ev m)
     add_executable(echo_test.out cmd/echo_test.c)
-    target_link_libraries(echo_test.out lsquic_adapter)
+    target_link_libraries(echo_test.out ${LIBS})
 ENDIF()
 
 MESSAGE(STATUS "Compiler flags: ${CMAKE_C_FLAGS}")

--- a/pkg/quic/lsquic/CMakeLists.txt
+++ b/pkg/quic/lsquic/CMakeLists.txt
@@ -22,9 +22,9 @@ IF(BUILD_LSQUIC)
     INCLUDE_DIRECTORIES(lsquic/include)
     INCLUDE_DIRECTORIES(lsquic/src/liblsquic)
     INCLUDE_DIRECTORIES(include)
-    ADD_LIBRARY(lsquic_adapter SHARED ./src/logger.c ./src/cert.c ./src/server.c ./src/keylog.c ./src/ancillary.c)
+    ADD_LIBRARY(adapter SHARED ./src/logger.c ./src/cert.c ./src/server.c ./src/keylog.c ./src/ancillary.c)
     SET(LIBS
-        lsquic_adapter
+        adapter
         ${CMAKE_SOURCE_DIR}/lsquic/src/liblsquic/liblsquic.so
         ${CMAKE_SOURCE_DIR}/boringssl/crypto/libcrypto.so
         ${CMAKE_SOURCE_DIR}/boringssl/ssl/libssl.so z ev m)

--- a/pkg/quic/lsquic/CMakeLists.txt
+++ b/pkg/quic/lsquic/CMakeLists.txt
@@ -24,12 +24,12 @@ IF(BUILD_LSQUIC)
     INCLUDE_DIRECTORIES(include)
     ADD_LIBRARY(adapter SHARED ./src/logger.c ./src/cert.c ./src/server.c ./src/keylog.c ./src/ancillary.c)
     SET(LIBS
-        adapter
-        ${CMAKE_SOURCE_DIR}/lsquic/src/liblsquic/liblsquic.so
-        ${CMAKE_SOURCE_DIR}/boringssl/crypto/libcrypto.so
-        ${CMAKE_SOURCE_DIR}/boringssl/ssl/libssl.so z ev m)
+        ${CMAKE_SOURCE_DIR}/liblsquic.so
+        ${CMAKE_SOURCE_DIR}/libcrypto.so
+        ${CMAKE_SOURCE_DIR}/libssl.so z ev m)
+    target_link_libraries(adapter ${LIBS})
     add_executable(echo_test.out cmd/echo_test.c)
-    target_link_libraries(echo_test.out ${LIBS})
+    target_link_libraries(echo_test.out ${LIBS} adapter)
 ENDIF()
 
 MESSAGE(STATUS "Compiler flags: ${CMAKE_C_FLAGS}")

--- a/pkg/quic/lsquic/adapter.c
+++ b/pkg/quic/lsquic/adapter.c
@@ -1,0 +1,162 @@
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "logger.h"
+#include "lsquic.h"
+#include "lsquic_int_types.h"
+#include "lsquic_util.h"
+
+struct lsquic_conn_ctx {
+    void* adapter_ctx;
+};
+
+struct lsquic_stream_ctx {
+    char* send_buffer;
+    size_t send_buffer_size;
+    void* adapter_ctx;
+};
+
+/* Adapter Callbacks */
+extern lsquic_stream_ctx_t* adapterOnNewConnection(lsquic_conn_t* conn, void* stream_if_ctx);
+extern void adapterOnClosedConnection(lsquic_conn_t* conn);
+extern void adapterOnNewStream(lsquic_stream_t* stream, void* adapter_ctx);
+extern void adapterOnRead(lsquic_stream_t* stream, char* buf, size_t buf_size,
+    void* adapter_ctx);
+extern void adapterOnClose(lsquic_stream_t* stream, void* adapter_ctx);
+
+/**/
+
+/* LSQUIC Callbacks */
+
+/*
+ * Callback to process the event of a new connection to the server
+ * */
+extern lsquic_conn_ctx_t* server_on_new_connection(void* stream_if_ctx,
+    struct lsquic_conn* conn);
+
+/*
+ * Callback to process the event of a closed connection to the server
+ * */
+extern void server_on_closed_connection(lsquic_conn_t* conn);
+
+extern lsquic_stream_ctx_t* server_on_new_stream(void* stream_if_ctx,
+    struct lsquic_stream* stream);
+
+extern void server_on_read(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+extern void server_on_write(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+extern void server_on_close(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+static const struct lsquic_stream_if stream_interface = {
+    .on_new_conn = server_on_new_connection,
+    .on_conn_closed = server_on_closed_connection,
+    .on_new_stream = server_on_new_stream,
+    .on_read = server_on_read,
+    .on_write = server_on_write,
+    .on_close = server_on_close,
+};
+
+/* stream methods */
+
+void print_conn_info(const lsquic_conn_t* conn)
+{
+    const char* cipher;
+
+    cipher = lsquic_conn_crypto_cipher(conn);
+
+    Log("Connection info: version: %u; cipher: %s; key size: %d, alg key size: "
+        "%d",
+        lsquic_conn_quic_version(conn), cipher ? cipher : "<null>",
+        lsquic_conn_crypto_keysize(conn), lsquic_conn_crypto_alg_keysize(conn));
+}
+
+lsquic_conn_ctx_t* server_on_new_connection(void* stream_if_ctx,
+    struct lsquic_conn* conn)
+{
+    const lsquic_cid_t* cid = lsquic_conn_id(conn);
+    char cid_string[0x29];
+    lsquic_hexstr(cid->idbuf, cid->len, cid_string, sizeof(cid_string));
+    const char* sni = lsquic_conn_get_sni(conn);
+    Log("new connection %s, for sni: %s", cid_string, sni ? sni : "not set");
+    print_conn_info(conn);
+    return NULL;
+}
+
+void server_on_closed_connection(lsquic_conn_t* conn)
+{
+    const lsquic_cid_t* cid = lsquic_conn_id(conn);
+    char cid_string[0x29];
+    lsquic_hexstr(cid->idbuf, cid->len, cid_string, sizeof(cid_string));
+    Log("Connection %s closed", cid_string);
+}
+
+lsquic_stream_ctx_t* server_on_new_stream(void* stream_if_ctx,
+    struct lsquic_stream* stream)
+{
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    Log("New Stream with id: %d", id);
+    lsquic_stream_ctx_t* stream_ctx = calloc(1, sizeof(*stream_ctx));
+    lsquic_stream_wantread(stream, true);
+    return stream_ctx;
+}
+
+void server_on_read(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx)
+{
+    struct lsquic_stream_ctx* const stream_data = (void*)stream_ctx;
+    ssize_t num_read;
+    unsigned char buf[0x400];
+
+    if (stream_ctx == NULL) {
+        Log("in %s: received NULL context", __func__);
+        lsquic_stream_close(stream);
+        return;
+    }
+
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    Log("Trying to read from Stream with id: %d", id);
+    num_read = lsquic_stream_read(stream, buf, sizeof(buf));
+
+    if (num_read < 0) {
+        /* This should not happen */
+        Log("error reading from stream (errno: %d) -- abort connection", errno);
+        lsquic_conn_abort(lsquic_stream_conn(stream));
+    }
+
+    Log("read %ld bytes", num_read);
+    lsquic_stream_wantread(stream, false);
+    lsquic_stream_wantwrite(stream, true);
+    // TODO: callback to treat data
+    // lsquic_stream_wantwrite(stream, 1);
+    return;
+}
+
+void server_on_write(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx)
+{
+    ssize_t num_written;
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    unsigned char buf[0x400];
+    num_written = lsquic_stream_write(stream, buf, sizeof(buf));
+    lsquic_stream_flush(stream);
+    if (num_written < 0) {
+        Log("lsquic_stream_write() returned %ld, abort connection",
+            (long)num_written);
+        lsquic_conn_abort(lsquic_stream_conn(stream));
+    }
+    Log("All data was written back, stopping stream");
+}
+
+void server_on_close(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx)
+{
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    Log("%s called, closing stream %u", __func__, id);
+    free(stream_ctx);
+}

--- a/pkg/quic/lsquic/adapter.c
+++ b/pkg/quic/lsquic/adapter.c
@@ -53,8 +53,7 @@ void server_on_closed_connection(lsquic_conn_t* conn)
 lsquic_stream_ctx_t* server_on_new_stream(void* stream_if_ctx,
     struct lsquic_stream* stream)
 {
-    lsquic_stream_ctx_t* stream_ctx = stream_if_ctx;
-    return adapterOnNewStream(stream, stream_ctx->adapter_ctx);
+    return adapterOnNewStream(stream, stream_if_ctx);
 }
 
 void server_on_read(struct lsquic_stream* stream,

--- a/pkg/quic/lsquic/adapter.h
+++ b/pkg/quic/lsquic/adapter.h
@@ -1,0 +1,45 @@
+#include "lsquic.h"
+#include "server.h"
+
+struct lsquic_conn_ctx {
+    void* adapter_ctx;
+};
+
+struct lsquic_stream_ctx {
+    char* send_buffer;
+    size_t send_buffer_size;
+    off_t send_buffer_off;
+    void* adapter_ctx;
+};
+
+/**/
+
+/* LSQUIC Callbacks */
+
+/*
+ * Callback to process the event of a new connection to the server
+ * */
+lsquic_conn_ctx_t* server_on_new_connection(void* stream_if_ctx,
+    struct lsquic_conn* conn);
+
+/*
+ * Callback to process the event of a closed connection to the server
+ * */
+void server_on_closed_connection(lsquic_conn_t* conn);
+
+lsquic_stream_ctx_t* server_on_new_stream(void* stream_if_ctx,
+    struct lsquic_stream* stream);
+
+void server_on_read(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+void server_on_write(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+void server_on_close(struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+bool lsquic_new_server(
+    Server* server,
+    const char* keylog,
+    void* stream_if_ctx);

--- a/pkg/quic/lsquic/cid.go
+++ b/pkg/quic/lsquic/cid.go
@@ -2,7 +2,7 @@ package lsquic
 
 /*
 #cgo CFLAGS: -I ./boringssl/include -I ./include -I ./lsquic/include -I ./lsquic/src/liblsquic
-#cgo LDFLAGS: -L . -L ./boringssl/ssl -L ./boringssl/crypto -L ./lsquic/src/liblsquic -l ev -l m -l z -l lsquic -l lsquic_adapter -l crypto -l ssl
+#cgo LDFLAGS: -L${SRCDIR}/. -ladapter -L${SRCDIR}/boringssl/ssl -lssl -L${SRCDIR}/boringssl/crypto -lcrypto -L${SRCDIR}/lsquic/src/liblsquic -llsquic -lev -lm -lz
 #include "lsquic_int_types.h"
 #include "lsquic_util.h"
 #include "lsquic.h"

--- a/pkg/quic/lsquic/cid.go
+++ b/pkg/quic/lsquic/cid.go
@@ -2,7 +2,7 @@ package lsquic
 
 /*
 #cgo CFLAGS: -I ./boringssl/include -I ./include -I ./lsquic/include -I ./lsquic/src/liblsquic
-#cgo LDFLAGS: -L${SRCDIR}/. -ladapter -L${SRCDIR}/boringssl/ssl -lssl -L${SRCDIR}/boringssl/crypto -lcrypto -L${SRCDIR}/lsquic/src/liblsquic -llsquic -lev -lm -lz
+#cgo LDFLAGS: -L${SRCDIR}/. -lev -lm -lz -lssl -lcrypto -llsquic
 #include "lsquic_int_types.h"
 #include "lsquic_util.h"
 #include "lsquic.h"

--- a/pkg/quic/lsquic/cid.go
+++ b/pkg/quic/lsquic/cid.go
@@ -1,0 +1,29 @@
+package lsquic
+
+/*
+#cgo CFLAGS: -I ./boringssl/include -I ./include -I ./lsquic/include -I ./lsquic/src/liblsquic
+#cgo LDFLAGS: -L . -L ./boringssl/ssl -L ./boringssl/crypto -L ./lsquic/src/liblsquic -l ev -l m -l z -l lsquic -l lsquic_adapter -l crypto -l ssl
+#include "lsquic_int_types.h"
+#include "lsquic_util.h"
+#include "lsquic.h"
+*/
+import "C"
+
+import adapter "poghttp3/pkg/quic"
+
+type LsQuicCID struct {
+	lsConn *C.lsquic_conn_t
+}
+
+func (l *LsQuicCID) String() string {
+	cid := C.lsquic_conn_id(l.lsConn)
+	cidString := [0x29]C.char{}
+	C.lsquic_hexstr(&cid.buf[0], C.ulong(cid.len), &cidString[0], 0x29)
+	return C.GoString(&cidString[0])
+}
+
+func NewLsquicCID(lsConn *C.lsquic_conn_t) adapter.QuicCID {
+	return &LsQuicCID{
+		lsConn: lsConn,
+	}
+}

--- a/pkg/quic/lsquic/cmd/echo.go
+++ b/pkg/quic/lsquic/cmd/echo.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	lsquic "poghttp3/pkg/quic/lsquic"
+)
+
+func main() {
+	api := lsquic.NewLsQuicApi()
+	lsquicServer, err := lsquic.NewLsquicServer("localhost:8080", "../certs/priv.key", "../certs/cert.crt", api)
+	if err != nil {
+		log.Println("failed to start lsquic server", err)
+		return
+	}
+	if err := lsquicServer.Listen(); err != nil {
+		log.Println("failed on server listen", err)
+	}
+}

--- a/pkg/quic/lsquic/cmd/echo_test.c
+++ b/pkg/quic/lsquic/cmd/echo_test.c
@@ -1,6 +1,68 @@
-#include "logger.h"
-#include "server.h"
+#include <errno.h>
 #include <stdlib.h>
+
+#include "logger.h"
+#include "lsquic.h"
+#include "lsquic_int_types.h"
+#include "lsquic_util.h"
+#include "server.h"
+
+struct lsquic_stream_ctx {
+    // total size of payload
+    size_t rcv_total_size;
+    // offset of written/read payload
+    off_t rcv_offset;
+    // payload data
+    char* rcv_buffer;
+    // used in conjunction to memstream to accumulate client data
+    FILE* file_handler;
+
+    size_t snd_total_size;
+    off_t snd_offset;
+    char* snd_buffer;
+
+    lsquic_stream_t* stream;
+    Server* server;
+};
+
+/* LSQUIC Callbacks */
+
+/*
+ * Callback to process the event of a new connection to the server
+ * */
+lsquic_conn_ctx_t* server_on_new_connection(
+    void* stream_if_ctx,
+    struct lsquic_conn* conn);
+
+/*
+ * Callback to process the event of a closed connection to the server
+ * */
+void server_on_closed_connection(lsquic_conn_t* conn);
+
+lsquic_stream_ctx_t* server_on_new_stream(
+    void* stream_if_ctx,
+    struct lsquic_stream* stream);
+
+void server_on_read(
+    struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+void server_on_write(
+    struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+void server_on_close(
+    struct lsquic_stream* stream,
+    lsquic_stream_ctx_t* stream_ctx);
+
+static const struct lsquic_stream_if stream_interface = {
+    .on_new_conn = server_on_new_connection,
+    .on_conn_closed = server_on_closed_connection,
+    .on_new_stream = server_on_new_stream,
+    .on_read = server_on_read,
+    .on_write = server_on_write,
+    .on_close = server_on_close,
+};
 
 int main(int _, char* argv[])
 {
@@ -18,7 +80,7 @@ int main(int _, char* argv[])
         return EXIT_FAILURE;
     }
 
-    ok = new_server(&server, "./keylog");
+    ok = new_server(&server, "./keylog", &stream_interface, &server);
     if (!ok) {
         Log("failure while creating new_server");
         return EXIT_FAILURE;
@@ -39,4 +101,120 @@ int main(int _, char* argv[])
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;
+}
+
+/* stream methods */
+
+void print_conn_info(const lsquic_conn_t* conn)
+{
+    const char* cipher;
+
+    cipher = lsquic_conn_crypto_cipher(conn);
+
+    Log("Connection info: version: %u; cipher: %s; key size: %d, alg key size: %d",
+        lsquic_conn_quic_version(conn),
+        cipher ? cipher : "<null>",
+        lsquic_conn_crypto_keysize(conn),
+        lsquic_conn_crypto_alg_keysize(conn));
+}
+
+lsquic_conn_ctx_t* server_on_new_connection(
+    void* stream_if_ctx,
+    struct lsquic_conn* conn)
+{
+    const lsquic_cid_t* cid = lsquic_conn_id(conn);
+    char cid_string[0x29];
+    lsquic_hexstr(cid->idbuf, cid->len, cid_string, sizeof(cid_string));
+    const char* sni = lsquic_conn_get_sni(conn);
+    Log("new connection %s, for sni: %s", cid_string, sni ? sni : "not set");
+    print_conn_info(conn);
+    return NULL;
+}
+
+void server_on_closed_connection(lsquic_conn_t* conn)
+{
+    const lsquic_cid_t* cid = lsquic_conn_id(conn);
+    char cid_string[0x29];
+    lsquic_hexstr(cid->idbuf, cid->len, cid_string, sizeof(cid_string));
+    Log("Connection %s closed", cid_string);
+}
+
+lsquic_stream_ctx_t* server_on_new_stream(
+    void* stream_if_ctx,
+    struct lsquic_stream* stream)
+{
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    Log("New Stream with id: %d", id);
+    lsquic_stream_ctx_t* stream_ctx = calloc(1, sizeof(*stream_ctx));
+    stream_ctx->stream = stream;
+    stream_ctx->server = stream_if_ctx;
+    stream_ctx->file_handler = open_memstream(&stream_ctx->rcv_buffer, &stream_ctx->rcv_total_size);
+    if (stream_ctx->file_handler == NULL) {
+        Log("failed to opem memstream");
+        free(stream_ctx);
+        return NULL;
+    }
+    lsquic_stream_wantread(stream, true);
+    return stream_ctx;
+}
+
+void server_on_read(struct lsquic_stream* stream, lsquic_stream_ctx_t* stream_ctx)
+{
+    struct lsquic_stream_ctx* const stream_data = (void*)stream_ctx;
+    ssize_t num_read;
+    unsigned char buf[0x400];
+
+    if (stream_ctx == NULL) {
+        Log("in %s: received NULL context", __func__);
+        lsquic_stream_close(stream);
+        return;
+    }
+
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    Log("Trying to read from Stream with id: %d", id);
+    num_read = lsquic_stream_read(stream, buf, sizeof(buf));
+
+    if (num_read < 0) {
+        /* This should not happen */
+        Log("error reading from stream (errno: %d) -- abort connection", errno);
+        lsquic_conn_abort(lsquic_stream_conn(stream));
+    }
+
+    fwrite(buf, 1, num_read, stream_data->file_handler);
+    fflush(stream_data->file_handler);
+    Log("read %ld bytes", num_read);
+    Log("read: '%.*s'", num_read, stream_data->rcv_buffer);
+    stream_data->snd_total_size = stream_data->rcv_total_size;
+    stream_data->snd_buffer = stream_data->rcv_buffer;
+    lsquic_stream_wantread(stream, false);
+    lsquic_stream_wantwrite(stream, true);
+    // TODO: callback to treat data
+    // lsquic_stream_wantwrite(stream, 1);
+    // TODO: write back when it is not a final response
+    return;
+}
+
+// TODO: this is only an echo test, change later
+void server_on_write(struct lsquic_stream* stream, lsquic_stream_ctx_t* stream_ctx)
+{
+    ssize_t num_written;
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    num_written = lsquic_stream_write(stream, stream_ctx->snd_buffer, stream_ctx->snd_total_size);
+    lsquic_stream_flush(stream);
+    if (num_written < 0) {
+        Log("lsquic_stream_write() returned %ld, abort connection", (long)num_written);
+        lsquic_conn_abort(lsquic_stream_conn(stream));
+    }
+    stream_ctx->snd_offset += num_written;
+    if (num_written >= 0 && stream_ctx->snd_offset == stream_ctx->snd_total_size) {
+        Log("All data was written back, stopping stream");
+    }
+}
+
+void server_on_close(struct lsquic_stream* stream, lsquic_stream_ctx_t* stream_ctx)
+{
+    lsquic_stream_id_t id = lsquic_stream_id(stream);
+    Log("%s called, closing stream %u", __func__, id);
+    free(stream_ctx->rcv_buffer); // TODO: not freeing snd_buffer because is echoing, change later
+    free(stream_ctx);
 }

--- a/pkg/quic/lsquic/include/server.h
+++ b/pkg/quic/lsquic/include/server.h
@@ -74,31 +74,17 @@ struct packet_buffer {
     unsigned buffer_size;
 };
 
-struct lsquic_stream_ctx {
-    // total size of payload
-    size_t rcv_total_size;
-    // offset of written/read payload
-    off_t rcv_offset;
-    // payload data
-    char* rcv_buffer;
-    // used in conjunction to memstream to accumulate client data
-    FILE* file_handler;
-
-    size_t snd_total_size;
-    off_t snd_offset;
-    char* snd_buffer;
-
-    lsquic_stream_t* stream;
-    Server* server;
-};
-
 /*
  * Creates a new server for the provided parameters
  *
  * consumer must check errno to ensure that the configuration was appropriate
  * and server can listen
  * */
-bool new_server(Server* server, const char* keylog);
+bool new_server(
+    Server* server,
+    const char* keylog,
+    const struct lsquic_stream_if* stream_if,
+    void* stream_if_ctx);
 
 void server_add_alpn(Server* server, char* const proto);
 
@@ -130,33 +116,3 @@ int server_write_socket(
     unsigned count);
 
 void server_read_socket(EV_P_ ev_io* w, int revents);
-
-/* LSQUIC Callbacks */
-
-/*
- * Callback to process the event of a new connection to the server
- * */
-lsquic_conn_ctx_t* server_on_new_connection(
-    void* stream_if_ctx,
-    struct lsquic_conn* conn);
-
-/*
- * Callback to process the event of a closed connection to the server
- * */
-void server_on_closed_connection(lsquic_conn_t* conn);
-
-lsquic_stream_ctx_t* server_on_new_stream(
-    void* stream_if_ctx,
-    struct lsquic_stream* stream);
-
-void server_on_read(
-    struct lsquic_stream* stream,
-    lsquic_stream_ctx_t* stream_ctx);
-
-void server_on_write(
-    struct lsquic_stream* stream,
-    lsquic_stream_ctx_t* stream_ctx);
-
-void server_on_close(
-    struct lsquic_stream* stream,
-    lsquic_stream_ctx_t* stream_ctx);

--- a/pkg/quic/lsquic/quic_api.go
+++ b/pkg/quic/lsquic/quic_api.go
@@ -1,0 +1,32 @@
+package lsquic
+
+import adapter "poghttp3/pkg/quic"
+
+// TODO:
+
+type LsQuicApi struct {
+}
+
+func (l *LsQuicApi) OnNewConnection(conn adapter.QuicCID) {
+
+}
+
+func (l *LsQuicApi) OnCanceledConn(conn adapter.QuicCID) {
+
+}
+
+func (l *LsQuicApi) OnNewStream(stream adapter.QuicStream) {
+
+}
+
+func (l *LsQuicApi) OnWriteStream(stream adapter.QuicStream) {
+
+}
+
+func (l *LsQuicApi) OnReadStream(stream adapter.QuicStream, data []byte) {
+
+}
+
+func NewLsQuicApi() adapter.QuicAPI {
+	return &LsQuicApi{}
+}

--- a/pkg/quic/lsquic/server.go
+++ b/pkg/quic/lsquic/server.go
@@ -1,0 +1,116 @@
+package lsquic
+
+/*
+#cgo CFLAGS: -I ./boringssl/include -I ./include -I ./lsquic/include -I ./lsquic/src/liblsquic
+#cgo LDFLAGS: -L . -L ./boringssl/ssl -L ./boringssl/crypto -L ./lsquic/src/liblsquic -l ev -l m -l z -l lsquic -l lsquic_adapter -l crypto -l ssl
+#include "lsquic_int_types.h"
+#include "lsquic_util.h"
+#include "lsquic.h"
+#include "logger.h"
+#include "server.h"
+#include "adapter.c"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+*/
+import "C"
+import (
+	"errors"
+	"fmt"
+	"log"
+	adapter "poghttp3/pkg/quic"
+	"unsafe"
+
+	gopointer "github.com/mattn/go-pointer"
+)
+
+type LsQuicServer struct {
+	lsServer *C.Server
+	quicApi  adapter.QuicAPI
+}
+
+func (l *LsQuicServer) Listen() error {
+	_, err := C.server_listen(l.lsServer)
+	if err != nil {
+		return errors.New(fmt.Sprintf("got error while trying to listen, errno: %s", err))
+	}
+	return nil
+}
+
+func NewLsquicServer(uri, keyfile, certfile string, api adapter.QuicAPI) (adapter.QuicServer, error) {
+	server := LsQuicServer{
+		lsServer: (*C.Server)(C.malloc(C.sizeof_Server)),
+		quicApi:  api,
+	}
+	streamCtx := gopointer.Save(server)
+	cUri := C.CString(uri)
+	defer C.free(unsafe.Pointer(cUri))
+	cKeyfile := C.CString(keyfile)
+	defer C.free(unsafe.Pointer(cKeyfile))
+	cCertfile := C.CString(certfile)
+	defer C.free(unsafe.Pointer(cCertfile))
+
+	ok, err := C.new_server(server.lsServer, nil, &C.stream_interface, streamCtx)
+	if !ok || err != nil {
+		return nil, errors.New("unable to create new server")
+	}
+
+	proto := C.CString("echo")
+	defer C.free(unsafe.Pointer(proto))
+	C.server_add_alpn(server.lsServer, proto)
+	if !ok {
+		return nil, errors.New("proto could not be inserted")
+	}
+	ok = C.add_v_server(server.lsServer, cUri, cCertfile, cKeyfile)
+	if !ok {
+		return nil, errors.New("could not create v_server")
+	}
+	return &server, nil
+}
+
+// export adapterOnNewConnection
+func adapterOnNewConnection(conn *C.lsquic_conn_t, streamCtx unsafe.Pointer) *C.lsquic_conn_ctx_t {
+	sni := C.lsquic_conn_get_sni(conn)
+	goSni := C.GoString(sni)
+	server, ok := gopointer.Restore(streamCtx).(LsQuicServer)
+	if !ok {
+		panic("passed on the incorrect type")
+	}
+	lsQuicCid := NewLsquicCID(conn)
+	server.quicApi.OnNewConnection(lsQuicCid)
+	log.Printf("on sni: %s\n", goSni)
+	connCtx := (*C.lsquic_conn_ctx_t)(C.malloc(C.sizeof_lsquic_conn_ctx_t))
+	connCtx.adapter_ctx = streamCtx
+	return connCtx
+}
+
+// export adapterOnClosedConnection
+func adapterOnClosedConnection(conn *C.lsquic_conn_t) {
+	connCtx := C.lsquic_conn_get_ctx(conn)
+	lsQuicCid := NewLsquicCID(conn)
+	server, ok := gopointer.Restore(connCtx.adapter_ctx).(LsQuicServer)
+	if !ok {
+		panic("passed on the incorrect type")
+	}
+	server.quicApi.OnCanceledConn(lsQuicCid)
+}
+
+// export adapterOnNewStream
+func adapterOnNewStream(stream *C.lsquic_stream_t, streamCtx unsafe.Pointer) *C.lsquic_stream_ctx_t {
+	streamCtxOut := (*C.lsquic_stream_ctx_t)(C.malloc(C.sizeof_lsquic_stream_ctx_t))
+	streamCtxOut.adapter_ctx = streamCtx
+	streamCtxOut.send_buffer = nil
+	streamCtxOut.send_buffer_size = 0
+	return streamCtxOut
+
+}
+
+// export adapterOnRead
+func adapterOnRead(stream *C.lsquic_stream_t, buf *C.char, buf_size C.size_t, adapter_cxt unsafe.Pointer) {
+
+}
+
+// export adapterOnClose
+func adapterOnClose(stream *C.lsquic_stream_t, adapter_cxt unsafe.Pointer) {
+
+}

--- a/pkg/quic/lsquic/setup.sh
+++ b/pkg/quic/lsquic/setup.sh
@@ -16,3 +16,5 @@ cd $LSQUIC
 echo "Building lsquic:"
 cmake -DCMAKE_CXX_COMPILER=g++-9 -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_FLAGS="-Wno-ignored-attributes" -DLSQUIC_SHARED_LIB=1 -DBORINGSSL_DIR=${BORINGSSL} . && make
 cd $ROOTDIR
+cp ./boringssl/crypto/libcrypto.so ./boringssl/ssl/libssl.so ./lsquic/src/liblsquic/liblsquic.so $ROOTDIR
+export LD_LIBRARY_PATH=${pwd}

--- a/pkg/quic/lsquic/src/server.c
+++ b/pkg/quic/lsquic/src/server.c
@@ -148,7 +148,6 @@ bool server_listen(Server* server)
     return true;
 }
 
-// TODO: improvement, pass the size of proto as parameter
 /*
  * Format used for ALPN
  * ┌───┬───┬───┬──────┐

--- a/pkg/quic/lsquic/stream.go
+++ b/pkg/quic/lsquic/stream.go
@@ -2,7 +2,7 @@ package lsquic
 
 /*
 #cgo CFLAGS: -I ./boringssl/include -I ./include -I ./lsquic/include -I ./lsquic/src/liblsquic
-#cgo LDFLAGS: -L${SRCDIR}/. -ladapter -L${SRCDIR}/boringssl/ssl -lssl -L${SRCDIR}/boringssl/crypto -lcrypto -L${SRCDIR}/lsquic/src/liblsquic -llsquic -lev -lm -lz
+#cgo LDFLAGS: -L${SRCDIR}/. -lev -lm -lz -lssl -lcrypto -llsquic -ladapter
 #include <stdlib.h>
 #include <stdbool.h>
 #include "lsquic.h"
@@ -32,7 +32,7 @@ func (l *LsQuicStream) Close() error {
 
 func (l *LsQuicStream) Write(p []byte) (n int, err error) {
 	if *l.sendBuffer != nil {
-		C.free(unsafe.Pointer(l.sendBuffer))
+		C.free(unsafe.Pointer(*l.sendBuffer))
 	}
 	*l.sendBufferSize = (C.size_t)(len(p))
 	*l.sendBufferOff = 0

--- a/pkg/quic/lsquic/stream.go
+++ b/pkg/quic/lsquic/stream.go
@@ -1,0 +1,40 @@
+package lsquic
+
+/*
+#cgo CFLAGS: -I ./boringssl/include -I ./include -I ./lsquic/include -I ./lsquic/src/liblsquic
+#cgo LDFLAGS: -L . -L ./boringssl/ssl -L ./boringssl/crypto -L ./lsquic/src/liblsquic -l ev -l m -l z -l lsquic -l lsquic_adapter -l crypto -l ssl
+#include "lsquic.h"
+#include <stdlib.h>
+#include <stdbool.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+type LsQuicStream struct {
+	lsStream       *C.lsquic_stream_t
+	sendBuffer     **C.char
+	sendBufferSize *C.size_t
+	sendBufferOff  *C.off_t
+}
+
+func (l *LsQuicStream) Close() error {
+	ok := C.lsquic_stream_close(l.lsStream)
+	if ok == 0 {
+		return nil
+	}
+	return fmt.Errorf("could not close stream")
+}
+
+func (l *LsQuicStream) Write(p []byte) (n int, err error) {
+	if *l.sendBuffer != nil {
+		C.free(unsafe.Pointer(l.sendBuffer))
+	}
+	*l.sendBufferSize = (C.size_t)(len(p))
+	*l.sendBufferOff = 0
+	*l.sendBuffer = (*C.char)(C.CBytes(p))
+	C.lsquic_stream_wantwrite(l.lsStream, C.true)
+	return len(p), nil
+}


### PR DESCRIPTION
With the use of [CGO](https://pkg.go.dev/cmd/cgo) and the LSQUIC interface presented in server.go, this implements a QUIC server that exposes an API for clients to use the protocol through the LiteSpeedTech library.

Note:

> Users should implement the _QuicApi_ interface and inject it into the constructor of _LsQuicServer_.